### PR TITLE
Alternative implementation of v4 using dynamic dispatch

### DIFF
--- a/y2020/ex04/src/lib.rs
+++ b/y2020/ex04/src/lib.rs
@@ -97,9 +97,7 @@ pub fn part2(lines: Vec<&str>) -> u32 {
 
         let is_valid = validators.iter().all(|(field, validator)| {
             if let Some(field_value) = passport.get(*field) {
-                if validator.validate(field_value) {
-                    return true;
-                }
+                return validator.validate(field_value);
             }
             false
         });

--- a/y2020/ex04/src/lib.rs
+++ b/y2020/ex04/src/lib.rs
@@ -1,6 +1,8 @@
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 
+mod validators;
+
 pub fn part1(lines: Vec<&str>) -> u32 {
     let expected_fields: HashSet<String> = vec!["byr", "iyr", "eyr", "hgt", "hcl", "ecl", "pid"]
         .into_iter()
@@ -49,61 +51,14 @@ pub fn part1(lines: Vec<&str>) -> u32 {
 }
 
 pub fn part2(lines: Vec<&str>) -> u32 {
-    type Validator = fn(&String) -> bool;
-    let mut validators: HashMap<String, Validator> = HashMap::new();
-    // byr (Birth Year) - four digits; at least 1920 and at most 2002.
-    validators.insert(String::from("byr"), |byr: &String| {
-        if let Ok(year) = byr.parse::<u16>() {
-            return (1920..=2002).contains(&year);
-        }
-        false
-    });
-    // iyr (Issue Year) - four digits; at least 2010 and at most 2020.
-    validators.insert(String::from("iyr"), |iyr: &String| {
-        if let Ok(year) = iyr.parse::<u16>() {
-            return (2010..=2020).contains(&year);
-        }
-        false
-    });
-    // eyr (Expiration Year) - four digits; at least 2020 and at most 2030.
-    validators.insert(String::from("eyr"), |eyr: &String| {
-        if let Ok(year) = eyr.parse::<u16>() {
-            return (2020..=2030).contains(&year);
-        }
-        false
-    });
-    // hgt (Height) - a number followed by either cm or in.
-    //   If cm, the number must be at least 150 and at most 193.
-    //   If in, the number must be at least 59 and at most 76.
-    validators.insert(String::from("hgt"), |hgt: &String| {
-        // TODO: see if we can move the regex outside the function
-        // maybe check lazy_static!
-        let hgt_regex = Regex::new(r"^(\d+)(in|cm)$").unwrap();
-        if let Some(captures) = hgt_regex.captures(hgt) {
-            let unit = captures.get(2).unwrap().as_str();
-
-            if let Ok(num) = captures.get(1).unwrap().as_str().parse::<u16>() {
-                return (unit == "in" && (59..=76).contains(&num))
-                    || (unit == "cm" && (150..=193).contains(&num));
-            }
-        }
-        false
-    });
-    // hcl (Hair Color) - a # followed by exactly six characters 0-9 or a-f.
-    validators.insert(String::from("hcl"), |hcl: &String| {
-        let color_regex = Regex::new(r"^#[0-9a-fA-F]{6}$").unwrap();
-        color_regex.is_match(hcl)
-    });
-    // ecl (Eye Color) - exactly one of: amb blu brn gry grn hzl oth.
-    validators.insert(String::from("ecl"), |ecl: &String| {
-        let color_regex = Regex::new(r"^(amb|blu|brn|gry|grn|hzl|oth)$").unwrap();
-        color_regex.is_match(ecl)
-    });
-    // pid (Passport ID) - a nine-digit number, including leading zeroes.
-    validators.insert(String::from("pid"), |pid: &String| {
-        let pid_regex = Regex::new(r"^\d{9}$").unwrap();
-        pid_regex.is_match(pid)
-    });
+    let mut validators: HashMap<&str, Box<dyn validators::Validator>> = HashMap::new();
+    validators.insert("byr", Box::from(validators::create_byr_validator()));
+    validators.insert("iyr", Box::from(validators::create_iyr_validator()));
+    validators.insert("eyr", Box::from(validators::create_eyr_validator()));
+    validators.insert("hgt", Box::from(validators::create_hgt_validator()));
+    validators.insert("hcl", Box::from(validators::create_hcl_validator()));
+    validators.insert("ecl", Box::from(validators::create_ecl_validator()));
+    validators.insert("pid", Box::from(validators::create_pid_validator()));
     // cid (Country ID) - ignored, missing or not.
     // This one is optional so we are not writing a validator for it
 
@@ -141,27 +96,13 @@ pub fn part2(lines: Vec<&str>) -> u32 {
             .collect();
 
         let is_valid = validators.iter().all(|(field, validator)| {
-            if let Some(field_value) = passport.get(field) {
-                if validator(field_value) {
+            if let Some(field_value) = passport.get(*field) {
+                if validator.validate(field_value) {
                     return true;
                 }
             }
             false
         });
-
-        // // ALTERNATIVE more verbose
-        // let mut is_valid = true;
-        // for (field, validator) in &validators {
-        //     if let Some(field_value) = passport.get(field) {
-        //         if !validator(field_value) {
-        //             is_valid = false;
-        //             break;
-        //         }
-        //     } else {
-        //         is_valid = false;
-        //         break;
-        //     }
-        // }
 
         if is_valid {
             valid_passports += 1;

--- a/y2020/ex04/src/lib.rs
+++ b/y2020/ex04/src/lib.rs
@@ -52,13 +52,13 @@ pub fn part1(lines: Vec<&str>) -> u32 {
 
 pub fn part2(lines: Vec<&str>) -> u32 {
     let mut validators: HashMap<&str, Box<dyn validators::Validator>> = HashMap::new();
-    validators.insert("byr", Box::from(validators::create_byr_validator()));
-    validators.insert("iyr", Box::from(validators::create_iyr_validator()));
-    validators.insert("eyr", Box::from(validators::create_eyr_validator()));
-    validators.insert("hgt", Box::from(validators::create_hgt_validator()));
-    validators.insert("hcl", Box::from(validators::create_hcl_validator()));
-    validators.insert("ecl", Box::from(validators::create_ecl_validator()));
-    validators.insert("pid", Box::from(validators::create_pid_validator()));
+    validators.insert("byr", Box::new(validators::create_byr_validator()));
+    validators.insert("iyr", Box::new(validators::create_iyr_validator()));
+    validators.insert("eyr", Box::new(validators::create_eyr_validator()));
+    validators.insert("hgt", Box::new(validators::create_hgt_validator()));
+    validators.insert("hcl", Box::new(validators::create_hcl_validator()));
+    validators.insert("ecl", Box::new(validators::create_ecl_validator()));
+    validators.insert("pid", Box::new(validators::create_pid_validator()));
     // cid (Country ID) - ignored, missing or not.
     // This one is optional so we are not writing a validator for it
 

--- a/y2020/ex04/src/validators.rs
+++ b/y2020/ex04/src/validators.rs
@@ -1,0 +1,106 @@
+use regex::Regex;
+use std::ops::RangeInclusive;
+
+pub trait Validator {
+    fn validate(&self, value: &str) -> bool;
+}
+
+pub struct U16RangeValidator {
+    range: RangeInclusive<u16>,
+}
+
+impl U16RangeValidator {
+    pub fn new(range: RangeInclusive<u16>) -> Self {
+        U16RangeValidator { range }
+    }
+}
+
+impl Validator for U16RangeValidator {
+    fn validate(&self, value: &str) -> bool {
+        if let Ok(year) = value.parse::<u16>() {
+            return self.range.contains(&year);
+        }
+        false
+    }
+}
+
+pub struct RegexValidator {
+    regex: Regex,
+}
+
+impl RegexValidator {
+    pub fn new(regex: Regex) -> Self {
+        RegexValidator { regex }
+    }
+}
+
+impl Validator for RegexValidator {
+    fn validate(&self, value: &str) -> bool {
+        self.regex.is_match(value)
+    }
+}
+
+// byr (Birth Year) - four digits; at least 1920 and at most 2002.
+pub fn create_byr_validator() -> U16RangeValidator {
+    U16RangeValidator::new(1920..=2002)
+}
+
+// iyr (Issue Year) - four digits; at least 2010 and at most 2020.
+pub fn create_iyr_validator() -> U16RangeValidator {
+    U16RangeValidator::new(2010..=2020)
+}
+
+// eyr (Expiration Year) - four digits; at least 2020 and at most 2030.
+pub fn create_eyr_validator() -> U16RangeValidator {
+    U16RangeValidator::new(2020..=2030)
+}
+
+// hgt (Height) - a number followed by either cm or in.
+//   If cm, the number must be at least 150 and at most 193.
+//   If in, the number must be at least 59 and at most 76.
+pub struct HgtValidator {
+    regex: Regex,
+}
+
+impl HgtValidator {
+    pub fn new() -> Self {
+        let regex = Regex::new(r"^(\d+)(in|cm)$").unwrap();
+        HgtValidator { regex }
+    }
+}
+
+impl Validator for HgtValidator {
+    fn validate(&self, value: &str) -> bool {
+        if let Some(captures) = self.regex.captures(value) {
+            let unit = captures.get(2).unwrap().as_str();
+
+            if let Ok(num) = captures.get(1).unwrap().as_str().parse::<u16>() {
+                return (unit == "in" && (59..=76).contains(&num))
+                    || (unit == "cm" && (150..=193).contains(&num));
+            }
+        }
+        false
+    }
+}
+
+pub fn create_hgt_validator() -> HgtValidator {
+    HgtValidator::new()
+}
+
+// hcl (Hair Color) - a # followed by exactly six characters 0-9 or a-f.
+pub fn create_hcl_validator() -> RegexValidator {
+    let regex = Regex::new(r"^#[0-9a-fA-F]{6}$").unwrap();
+    RegexValidator::new(regex)
+}
+
+// ecl (Eye Color) - exactly one of: amb blu brn gry grn hzl oth.
+pub fn create_ecl_validator() -> RegexValidator {
+    let regex = Regex::new(r"^(amb|blu|brn|gry|grn|hzl|oth)$").unwrap();
+    RegexValidator::new(regex)
+}
+
+// pid (Passport ID) - a nine-digit number, including leading zeroes.
+pub fn create_pid_validator() -> RegexValidator {
+    let regex = Regex::new(r"^\d{9}$").unwrap();
+    RegexValidator::new(regex)
+}


### PR DESCRIPTION
Dynamic dispatch allows us to avoid recreating instances of regex (and ranges) every time we try to validate a field.

Possibly a bit more verbose, but on the other end, by having a dedicated `validators` module it is now possible to add tests for specific validators. Also, the code is a bit more generalised because we have more generic range and regex validator structs.