### PR TITLE
add benchmarks for y2020 ex13 part2

### DIFF
--- a/y2020/ex13/Cargo.toml
+++ b/y2020/ex13/Cargo.toml
@@ -7,3 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "my_benchmark"
+harness = false

--- a/y2020/ex13/benches/my_benchmark.rs
+++ b/y2020/ex13/benches/my_benchmark.rs
@@ -1,0 +1,15 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ex13::part2;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let input = include_str!("../input.txt");
+    c.bench_function(
+        "part2",
+        |b| b.iter(
+            || part2(black_box(input))
+        )
+    );
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
add benchmarks for y2020 ex13 part2

run 

```
cargo bench
```

It is faster if you run it in the `y2020/ex13` folder, but works also from the repo root