### PR TITLE
y2021 day4: Using trait object to avoid collecting

### DIFF
--- a/y2021/ex04/src/lib.rs
+++ b/y2021/ex04/src/lib.rs
@@ -20,7 +20,11 @@ impl Board {
     }
 
     fn score(&self, final_num: u64) -> u64 {
-        self.rows.iter().map(|set| set.iter().sum::<u64>()).sum::<u64>() * final_num
+        self.rows
+            .iter()
+            .map(|set| set.iter().sum::<u64>())
+            .sum::<u64>()
+            * final_num
     }
 }
 
@@ -43,9 +47,9 @@ impl FromStr for Board {
     }
 }
 
-fn parse_input(input: &str) -> (Vec<u64>, Vec<Board>) {
+fn parse_input(input: &str) -> (impl Iterator<Item = u64> + '_, Vec<Board>) {
     let (raw_seq, raw_boards) = input.split_once("\n\n").unwrap();
-    let seq = raw_seq.split(',').map(|n| n.parse::<u64>().unwrap()).collect();
+    let seq = raw_seq.split(',').map(|n| n.parse::<u64>().unwrap());
 
     let boards: Vec<Board> = raw_boards
         .split("\n\n")

--- a/y2021/ex04/src/lib.rs
+++ b/y2021/ex04/src/lib.rs
@@ -47,22 +47,25 @@ impl FromStr for Board {
     }
 }
 
-fn parse_input(input: &str) -> (impl Iterator<Item = u64> + '_, Vec<Board>) {
+fn parse_input(
+    input: &str,
+) -> (
+    impl Iterator<Item = u64> + '_,
+    impl Iterator<Item = Board> + '_,
+) {
     let (raw_seq, raw_boards) = input.split_once("\n\n").unwrap();
     let seq = raw_seq.split(',').map(|n| n.parse::<u64>().unwrap());
 
-    let boards: Vec<Board> = raw_boards
-        .split("\n\n")
-        .map(|b| b.parse().unwrap())
-        .collect();
+    let boards = raw_boards.split("\n\n").map(|b| b.parse().unwrap());
     (seq, boards)
 }
 
 pub fn part1(input: &str) -> u64 {
-    let (seq, mut boards) = parse_input(input);
+    let (seq, boards) = parse_input(input);
+    let mut all_boards: Vec<Board> = boards.collect();
 
     for num in seq {
-        for board in boards.iter_mut() {
+        for board in all_boards.iter_mut() {
             if board.mark(num) {
                 return board.score(num);
             }
@@ -73,8 +76,9 @@ pub fn part1(input: &str) -> u64 {
 }
 
 pub fn part2(input: &str) -> u64 {
-    let (seq, mut boards) = parse_input(input);
-    let mut active_boards: Vec<&mut Board> = boards.iter_mut().collect();
+    let (seq, boards) = parse_input(input);
+    let mut all_boards: Vec<Board> = boards.collect();
+    let mut active_boards: Vec<&mut Board> = all_boards.iter_mut().collect();
 
     for num in seq {
         if active_boards.len() == 1 {


### PR DESCRIPTION
I figured out how to use a [trait object](https://doc.rust-lang.org/reference/types/trait-object.html) to avoid collecting (allocation)

```rust
impl Iterator<Item=u64> + '_
```

stands for "any object that implements the `Iterator` trait with `Item` associated type `u64` (and infer the lifetime)"