### PR TITLE
y2021ex24 Make Clippy Happy 🥲

### DIFF
--- a/y2021/ex24/src/lib.rs
+++ b/y2021/ex24/src/lib.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 fn parse_input(input: &str) -> [(i8, i8, i8); 14] {
     let mut res: [(i8, i8, i8); 14] = Default::default();
     let mut lines = input.lines();
-    for i in 0..14 {
+    for entry in res.iter_mut() {
         for _ in 0..4 {
             lines.next(); // skip 4 lines without moving the iterator
         }
@@ -24,7 +24,7 @@ fn parse_input(input: &str) -> [(i8, i8, i8); 14] {
             lines.next(); // skip 2 lines without moving the iterator
         }
 
-        res[i] = (a, b, c);
+        *entry = (a, b, c);
     }
 
     res


### PR DESCRIPTION
Fixes Clippy warning about [`needless_range_loop`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop)