### PR TITLE
Clippy likes short format strings (and other minor things)

### DIFF
--- a/y2020/ex19/src/lib.rs
+++ b/y2020/ex19/src/lib.rs
@@ -2,14 +2,14 @@ use std::collections::HashMap;
 
 type RuleId = usize;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 enum Rule {
     Seq(Vec<RuleId>),
     Fork(Vec<RuleId>, Vec<RuleId>),
     Leaf(char),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 struct RuleSet(HashMap<RuleId, Rule>);
 
 fn create_ruleset(raw_rules: &str) -> RuleSet {
@@ -131,7 +131,19 @@ mod ex17_tests {
 
         let ruleset = create_ruleset(rules);
 
-        println!("{:#?}", ruleset);
+        assert_eq!(
+            ruleset,
+            RuleSet(
+                vec![
+                    (0, Rule::Seq(vec![1, 2])),
+                    (1, Rule::Leaf('a')),
+                    (2, Rule::Fork(vec![1, 3], vec![3, 1])),
+                    (3, Rule::Leaf('b'))
+                ]
+                .into_iter()
+                .collect()
+            )
+        );
     }
 
     #[test]
@@ -146,8 +158,21 @@ mod ex17_tests {
         ";
 
         let ruleset = create_ruleset(rules);
-
-        println!("{:#?}", ruleset);
+        assert_eq!(
+            ruleset,
+            RuleSet(
+                vec![
+                    (0, Rule::Seq(vec![4, 1, 5])),
+                    (1, Rule::Fork(vec![2, 3], vec![3, 2])),
+                    (2, Rule::Fork(vec![4, 4], vec![5, 5])),
+                    (3, Rule::Fork(vec![4, 5], vec![5, 4])),
+                    (4, Rule::Leaf('a')),
+                    (5, Rule::Leaf('b'))
+                ]
+                .into_iter()
+                .collect()
+            )
+        );
     }
 
     #[test]

--- a/y2021/ex11/src/lib.rs
+++ b/y2021/ex11/src/lib.rs
@@ -18,7 +18,7 @@ impl<const N: usize> Display for OctoGrid<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for row in self.0 {
             for cell in row {
-                write!(f, "{}", cell)?;
+                write!(f, "{cell}")?;
             }
             writeln!(f)?;
         }

--- a/y2021/ex15/src/lib.rs
+++ b/y2021/ex15/src/lib.rs
@@ -49,7 +49,7 @@ impl<const N: usize> Display for CaveMap<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for row in self.cave {
             let line: String = row.iter().map(|v| v.to_string()).collect();
-            writeln!(f, "{}", line)?;
+            writeln!(f, "{line}")?;
         }
 
         Ok(())

--- a/y2021/ex23/src/amphipod.rs
+++ b/y2021/ex23/src/amphipod.rs
@@ -37,7 +37,7 @@ impl From<char> for Amphipod {
             'B' => Amphipod::B,
             'C' => Amphipod::C,
             'D' => Amphipod::D,
-            _ => panic!("Invalid amphipod: {}", c),
+            _ => panic!("Invalid amphipod: {c}"),
         }
     }
 }

--- a/y2021/ex25/src/lib.rs
+++ b/y2021/ex25/src/lib.rs
@@ -11,7 +11,7 @@ impl From<char> for Cell {
         match c {
             'v' => Cell::Down,
             '>' => Cell::Right,
-            _ => panic!("Invalid cell: {}", c),
+            _ => panic!("Invalid cell: {c}"),
         }
     }
 }
@@ -178,7 +178,7 @@ v.v..>>v.v
         let mut counter = 0;
         loop {
             counter += 1;
-            println!("{} ---\n\n {}\n", counter, g1);
+            println!("{counter} ---\n\n {g1}\n");
             let changed = g1.step(g2);
             mem::swap(&mut g1, &mut g2);
 

--- a/y2022/ex10/src/display.rs
+++ b/y2022/ex10/src/display.rs
@@ -41,7 +41,7 @@ impl std::fmt::Display for Display {
         let mut chars = self.pixels.chars();
         for _ in 0..6 {
             let line = chars.by_ref().take(40).collect::<String>();
-            writeln!(f, "{}", line)?;
+            writeln!(f, "{line}")?;
         }
         Ok(())
     }

--- a/y2022/ex12/src/map.rs
+++ b/y2022/ex12/src/map.rs
@@ -174,7 +174,7 @@ impl<const W: usize, const H: usize> FromStr for Map<W, H> {
                         0
                     }
                     'b'..='z' => c as usize - 'a' as usize,
-                    _ => return Err(format!("Unexpected character '{}'", c)),
+                    _ => return Err(format!("Unexpected character '{c}'")),
                 };
                 grid[y][x] = elevation;
             }

--- a/y2022/ex13/src/packet.rs
+++ b/y2022/ex13/src/packet.rs
@@ -229,7 +229,7 @@ mod test {
         for (left, right, expected) in cases.iter() {
             let left = parse_packet(left).unwrap().1;
             let right = parse_packet(right).unwrap().1;
-            assert_eq!(left.cmp(&right), *expected, "{:?} vs {:?}", left, right);
+            assert_eq!(left.cmp(&right), *expected, "{left:?} vs {right:?}");
         }
     }
 }

--- a/y2022/ex25/src/lib.rs
+++ b/y2022/ex25/src/lib.rs
@@ -19,7 +19,7 @@ impl FromStr for Snafu {
                 '0' | '1' | '2' => c.to_string().parse().unwrap(),
                 '-' => -1,
                 '=' => -2,
-                _ => return Err(format!("Invalid character: {}", c)),
+                _ => return Err(format!("Invalid character: {c}")),
             };
 
             val += n * 5_i64.pow(i as u32);
@@ -52,7 +52,7 @@ impl Display for Snafu {
         }
 
         let s = chars.iter().rev().collect::<String>();
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -95,7 +95,7 @@ mod tests {
         for (num, expected) in cases {
             let snafu: Snafu = num.into();
             let result = snafu.to_string();
-            assert_eq!(result, expected, "Failed for {}", num);
+            assert_eq!(result, expected, "Failed for {num}");
             // reverse the operation
             let snafu2: Snafu = result.parse().unwrap();
             assert_eq!(snafu, snafu2);


### PR DESCRIPTION
... and it doesn't like `println!()` in tests